### PR TITLE
[Prototype] Feature: Look word up in dictionary site

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -38,6 +38,9 @@
   "learningService": {
     "message": "Learning service"
   },
+  "customSite": {
+    "message": "Custom site"
+  },
   "subtitlesSize": {
     "message": "Subtitles size"
   },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -38,6 +38,9 @@
   "learningService": {
     "message": "Сервис изучения языка"
   },
+  "customSite": {
+    "message": "Custom site"
+  },
   "subtitlesSize": {
     "message": "Размер субтитров"
   },

--- a/src/components/settings/Content.tsx
+++ b/src/components/settings/Content.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import Language from "./Language";
 import LearningService from "./LearningService";
+import CustomSite from "./CustomSite";
 import Toggle from "./Toggle";
 import ShowProgressBar from "./ShowProgressBar";
 import SubsFontSize from "./SubsFontSize";
@@ -36,6 +37,7 @@ const Content = (props: any) => {
         <ShowProgressBar />
         <Language />
         <LearningService />
+        <CustomSite />
         {/* <div className="easysubs-settings__content__header">Interface</div> */}
         <div className="easysubs-settings__content__header">
           {chrome.i18n.getMessage("subtitles")}

--- a/src/components/settings/CustomSite.tsx
+++ b/src/components/settings/CustomSite.tsx
@@ -1,0 +1,29 @@
+import { useStore } from "effector-react";
+import React from "react";
+import { setCustomSite } from "../../event";
+import { customSiteStore } from "../../store";
+
+function CustomSite() {
+  const currentSite = useStore(customSiteStore);
+
+  function changeCustomSite(site: string) {
+    setCustomSite(site)
+  }
+
+  return (
+    <div className="easysubs-settings__learning-service easysubs-settings__item">
+      <div className="easysubs-settings__item__left-side">
+        <span>{chrome.i18n.getMessage("customSite")}</span>
+      </div>
+      <div className="easysubs-settings__item__right-side">
+        <input type="text" style={{color: 'black'}}
+          value={currentSite || ""}
+          onChange={e => changeCustomSite(e.target.value || null)}
+        />
+      </div>
+    </div>
+  );
+}
+customSiteStore.on(setCustomSite, (state: any, site: object) => site);
+
+export default CustomSite;

--- a/src/components/subs/TranslateWordPopup.tsx
+++ b/src/components/subs/TranslateWordPopup.tsx
@@ -1,6 +1,7 @@
 import { useStore } from "effector-react";
 import React, { useEffect, useState, useRef } from "react";
 import { userLanguageStore } from "../../store";
+import { customSiteStore } from "../../store";
 import Utils from "../../utils";
 import TranslateAlternatives from "./TranslateAlternatives";
 
@@ -23,6 +24,7 @@ function TranslateWordPopup(props: Props) {
   });
   const language = useStore(userLanguageStore);
   const isUnmounted = useRef(false);
+  const urlTemplate = useStore(customSiteStore)
 
   useEffect(() => {
     chrome.runtime.sendMessage(
@@ -48,6 +50,10 @@ function TranslateWordPopup(props: Props) {
     };
   }, []);
 
+  function getUrl(word: String) {
+    return urlTemplate.replace("${word}", word)
+  }
+
   if (translation.original !== "") {
     return (
       <div className="easysubs-translate-container">
@@ -58,6 +64,7 @@ function TranslateWordPopup(props: Props) {
         <div className="easysubs-translate-original">
           {translation.original}
         </div>
+        {urlTemplate && <div><a href={getUrl(translation.original)} target="_blank">open</a></div>}
         <TranslateAlternatives alternativesGroups={translation.alternatives} word={props.word} context={props.context} />
       </div>
     );

--- a/src/components/subs/TranslateWordPopup.tsx
+++ b/src/components/subs/TranslateWordPopup.tsx
@@ -64,8 +64,8 @@ function TranslateWordPopup(props: Props) {
         <div className="easysubs-translate-original">
           {translation.original}
         </div>
-        {urlTemplate && <div><a href={getUrl(translation.original)} target="_blank">open</a></div>}
         <TranslateAlternatives alternativesGroups={translation.alternatives} word={props.word} context={props.context} />
+        {urlTemplate && <div><a href={getUrl(translation.original)} target="_blank">open</a></div>}
       </div>
     );
   }

--- a/src/event.ts
+++ b/src/event.ts
@@ -5,6 +5,7 @@ export const toggleShowProgressBarState = createEvent("Toggle show progress bar 
 export const toggleShowSubsBackgroundState = createEvent("Toggle show subs background");
 export const setUserLanguage = createEvent("Set user language");
 export const setLearningService = createEvent("Set learning service");
+export const setCustomSite = createEvent("Set custom site");
 
 export const updateSubs = createEvent("Update subtitles");
 export const videoTimeUpdate = createEvent("Video time update");

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,6 +8,7 @@ export const showSubsBackgroundState = withPersist(createStore(true));
 export const subsFontSizeStore = withPersist(createStore(100));
 export const userLanguageStore = withPersist(createStore(window.navigator.language.split("-")[0]));
 export const learningServiceStore = withPersist(createStore(null));
+export const customSiteStore = withPersist(createStore(null));
 export const subsStore = createStore(parse(""));
 export const showFullSubTranslatePopupStore = createStore(false);
 export const autoPauseStore = createStore(false);


### PR DESCRIPTION
Hi, I tried to add a feature to let user look up their favorite dictionary site quickly.

For example, if user set `https://www.dictionary.com/browse/${word}`:
![Screen Shot 2021-02-26 at 21 14 58](https://user-images.githubusercontent.com/33222939/109299760-f6fb3900-7878-11eb-8f7b-bb8247520611.png)

Then he/she can go to https://www.dictionary.com/browse/chilly easily by clicking "open":
![Screen Shot 2021-02-26 at 21 15 35](https://user-images.githubusercontent.com/33222939/109299766-f82c6600-7878-11eb-9d0c-b0800197a33b.png)

I'm not familiar with UI design, so it's just a prototype😅