### PR TITLE
Kinopub: use new cdn url

### DIFF
--- a/src/services/kinopub.ts
+++ b/src/services/kinopub.ts
@@ -31,7 +31,7 @@ class KinoPub implements Service {
     parser.end();
     const subsSegments = parser.manifest.mediaGroups.SUBTITLES.sub;
 
-    const uri = `https://cdn.streambox.in${subsSegments[label].uri}`;
+    const uri = `https://yandex-cdn.net${subsSegments[label].uri}`;
     const subsSegmentsResp = await fetch(uri);
     const subsSegmentsData = await subsSegmentsResp.text();
 
@@ -39,7 +39,7 @@ class KinoPub implements Service {
     subsSegmentsParser.push(subsSegmentsData);
     subsSegmentsParser.end();
     const subPath = subsSegmentsParser.manifest.segments[0].uri.match(/.*\/hls\/(.*)\/seg.*/)[1];
-    const subUri = `https://cdn.streambox.in/pd/${subPath}`;
+    const subUri = `https://yandex-cdn.net/pd/${subPath}`;
 
     const subsResp = await fetch(subUri);
     const subsData = await subsResp.text();


### PR DESCRIPTION
I noticed that Easysubs no longer starts on Kinopub. It seems that the problem is that the extension contains CDN domain names which are no longer accessible.

At the moment I am using updated version which works just fine.