### PR TITLE
Fix response handler for adding a new word to puzzle-english.com service

### DIFF
--- a/src/learning-services/PuzzleEnglish.ts
+++ b/src/learning-services/PuzzleEnglish.ts
@@ -11,7 +11,7 @@ class PuzzleEnglish {
 
     return new Promise((resolve, reject) => {
       chrome.runtime.sendMessage({ contentScriptQuery: "postFormDataRequest", url: url, data: data }, response => {
-        response.status
+        response.success
           ? resolve(chrome.i18n.getMessage("wordAddedToPuzzleEnglish"))
           : reject("Puzzle English Error: " + response.error);
       });


### PR DESCRIPTION
On the latest version of the easysubs extension, we getting an error message about adding a new word to the puzzle-english.com service:

![Screenshot 2021-07-17 at 16 59 40](https://user-images.githubusercontent.com/1436683/126040047-8cd21a0c-6f0b-44c7-9160-6fb0c67b7fb5.png)

Looks like it was changed API response for method `https://puzzle-english.com/api2/userDictionary/addWord` and now it sends `success: true` if everything ok with the request:

![Screenshot 2021-07-17 at 16 58 39](https://user-images.githubusercontent.com/1436683/126040106-9e4a9f8c-348c-465d-88df-248dd8dbed27.png)
