### PR TITLE
Add Jellyfin streaming service support

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/src/assets/style/content/global.scss
+++ b/src/assets/style/content/global.scss
@@ -128,7 +128,7 @@
 .es-jellyfin.es-enabled {
   #es {
     position: fixed;
-    z-index: 9999;
+    z-index: 2147483647;
     bottom: 100px;
     pointer-events: auto;
 
@@ -136,9 +136,7 @@
       bottom: 80px;
     }
 
-    .es-sub,
-    .es-sub-item,
-    pre {
+    * {
       pointer-events: auto;
     }
   }

--- a/src/assets/style/content/global.scss
+++ b/src/assets/style/content/global.scss
@@ -109,6 +109,41 @@
   }
 }
 
+.es-jellyfin {
+  .es-settings-icon {
+    svg {
+      width: 28px;
+    }
+  }
+
+  .es-settings-content {
+    position: fixed;
+    z-index: 2147483647;
+    bottom: 80px;
+    right: 20px;
+    pointer-events: auto;
+  }
+}
+
+.es-jellyfin.es-enabled {
+  #es {
+    position: fixed;
+    z-index: 9999;
+    bottom: 100px;
+    pointer-events: auto;
+
+    @media screen and (max-width: 1520px) {
+      bottom: 80px;
+    }
+
+    .es-sub,
+    .es-sub-item,
+    pre {
+      pointer-events: auto;
+    }
+  }
+}
+
 .es-enabled {
   #es {
     display: block;

--- a/src/assets/style/content/progress-bar.scss
+++ b/src/assets/style/content/progress-bar.scss
@@ -41,6 +41,17 @@
   }
 }
 
+.es-jellyfin.es-enabled.es-progress-bar-enabled {
+  .es-progress-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    z-index: 9998;
+  }
+}
+
 .es-kinopub.es-enabled.es-progress-bar-enabled {
   .jw-controlbar {
     bottom: 15px;

--- a/src/models/subs/init.ts
+++ b/src/models/subs/init.ts
@@ -96,18 +96,6 @@ $rawSubs.on(
   (_, subs) => subs
 );
 
-$rawSubs.on(rawSubsAdded, (oldSubs, newSubs) => {
-  const lastSub = oldSubs[oldSubs.length - 1];
-  if (!lastSub) {
-    return [...oldSubs, ...newSubs];
-  }
-  if (lastSub.text != newSubs[0].text && lastSub.start != newSubs[0].start) {
-    const subs = oldSubs.slice(0, -1);
-    lastSub.end = lastSub.start;
-    return [...subs, ...[lastSub], ...newSubs];
-  }
-});
-
 $rawSubs.reset(resetSubs);
 $currentSubs.on([updateCurrentSubsFx.doneData, autoPauseFx.doneData], (oldSubs, subs) =>
   JSON.stringify(oldSubs) === JSON.stringify(subs) ? oldSubs : subs

--- a/src/pages/content/components/Settings/JellyfinSubTrack.tsx
+++ b/src/pages/content/components/Settings/JellyfinSubTrack.tsx
@@ -1,0 +1,69 @@
+import { FC, useEffect, useState } from "react";
+import { useUnit } from "effector-react";
+import { $video } from "@src/models/videos";
+import { esSubsChanged } from "@src/models/subs";
+import { Select } from "../ui/Select/Select";
+
+type TrackOption = { value: number; label: string };
+
+const DISABLED_OPTION: TrackOption = { value: -1, label: "Disabled" };
+
+export const JellyfinSubTrack: FC = () => {
+  const video = useUnit($video);
+  const [options, setOptions] = useState<TrackOption[]>([]);
+  const [selected, setSelected] = useState<TrackOption>(DISABLED_OPTION);
+
+  useEffect(() => {
+    if (!video) return;
+
+    const buildOptions = () => {
+      const opts: TrackOption[] = [DISABLED_OPTION];
+      let active: TrackOption = DISABLED_OPTION;
+      for (let i = 0; i < video.textTracks.length; i++) {
+        const t = video.textTracks[i];
+        if (t.kind !== "subtitles" && t.kind !== "captions") continue;
+        const label = t.label || t.language || `Track ${i}`;
+        opts.push({ value: i, label });
+        if (t.mode !== "disabled") active = { value: i, label };
+      }
+      setOptions(opts);
+      setSelected(active);
+    };
+
+    buildOptions();
+    video.textTracks.addEventListener("change", buildOptions);
+    video.textTracks.addEventListener("addtrack", buildOptions);
+    return () => {
+      video.textTracks.removeEventListener("change", buildOptions);
+      video.textTracks.removeEventListener("addtrack", buildOptions);
+    };
+  }, [video]);
+
+  const handleChange = (opt: TrackOption | null) => {
+    if (!video || !opt) return;
+    for (let i = 0; i < video.textTracks.length; i++) {
+      const t = video.textTracks[i];
+      if (t.kind !== "subtitles" && t.kind !== "captions") continue;
+      t.mode = i === opt.value ? "showing" : "disabled";
+    }
+    if (opt.value === -1) {
+      esSubsChanged(""); // Clear the EasySubs overlay immediately
+    }
+    setSelected(opt);
+  };
+
+  if (options.length <= 1) return null;
+
+  return (
+    <div className="es-settings-content__element">
+      <div className="es-settings-content__element__left">Subtitle track</div>
+      <div className="es-settings-content__element__right">
+        <Select
+          options={options}
+          value={selected}
+          onChange={(opt) => handleChange(opt as TrackOption)}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/pages/content/components/Settings/SettingsContent.tsx
+++ b/src/pages/content/components/Settings/SettingsContent.tsx
@@ -22,7 +22,9 @@ import {
 } from "@src/models/settings";
 import { EnableNetflixOnFlight } from "./EnableNetflixOnFlight";
 import { EnableAutoStop } from "./EnableAutoStop";
+import { JellyfinSubTrack } from "./JellyfinSubTrack";
 import { createPortal } from "react-dom";
+import { $streaming } from "@src/models/streamings";
 
 interface TabProps {
   isActive: boolean;
@@ -48,9 +50,10 @@ const Tab: FC<PropsWithChildren<TabProps>> = ({
 };
 
 export const SettingsContent: FC<{ onClose: () => void }> = ({ onClose }) => {
-  const [activeSettingsTab, handleActiveSettingsTabChanged] = useUnit([
+  const [activeSettingsTab, handleActiveSettingsTabChanged, streaming] = useUnit([
     $activeSettingsTab,
     activeSettingsTabChanged,
+    $streaming,
   ]);
   const contentRef = useRef();
 
@@ -58,7 +61,7 @@ export const SettingsContent: FC<{ onClose: () => void }> = ({ onClose }) => {
 
   return (
     <>
-      <div className="es-settings-content" ref={contentRef}>
+      <div className="es-settings-content" ref={contentRef} onClick={(e) => e.stopPropagation()}>
         <div className="es-settings-content__menu">
           <div className="es-settings-content__menu__items">
             <Tab
@@ -130,6 +133,11 @@ export const SettingsContent: FC<{ onClose: () => void }> = ({ onClose }) => {
               <div className="es-settings-content__item">
                 <SubsDelay />
               </div>
+              {streaming.name === "jellyfin" && (
+                <div className="es-settings-content__item">
+                  <JellyfinSubTrack />
+                </div>
+              )}
               <div className="es-settings-content__item">
                 <CustomSubs />
               </div>

--- a/src/pages/content/components/Subs/Subs.tsx
+++ b/src/pages/content/components/Subs/Subs.tsx
@@ -59,7 +59,7 @@ export const Subs: FC<TSubsProps> = () => {
   };
 
   return (
-    <Draggable>
+    <Draggable cancel=".es-sub">
       <div
         id="es-subs"
         onMouseLeave={handleOnMouseLeave}
@@ -133,9 +133,10 @@ const SubItem: FC<TSubItemProps> = ({ subItem, index }) => {
     handleSubItemMouseEntered(subItem.cleanedText);
   };
 
-  const handleClick = () => {
-    setShowTranslation(false);
-    handleSubItemMouseLeft();
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowTranslation(true);
+    handleSubItemMouseEntered(subItem.cleanedText);
   };
 
   return (

--- a/src/pages/content/components/Subs/Subs.tsx
+++ b/src/pages/content/components/Subs/Subs.tsx
@@ -64,6 +64,7 @@ export const Subs: FC<TSubsProps> = () => {
         id="es-subs"
         onMouseLeave={handleOnMouseLeave}
         onMouseEnter={handleOnMouseEnter}
+        onClick={(e) => e.stopPropagation()}
         style={{ fontSize: `${((video.clientWidth / 100) * subsFontSize) / 43}px` }}
       >
         {currentSubs.map((sub) => (

--- a/src/pages/content/components/ui/Select/Select.tsx
+++ b/src/pages/content/components/ui/Select/Select.tsx
@@ -11,8 +11,8 @@ const customStyles = {
     minHeight: "24px",
     height: "24px",
   }),
-  menuPortal: (provided) => ({ ...provided, zIndex: 10000, fontSize: "14px" }),
-  menu: (provided) => ({ ...provided, zIndex: 10000 }),
+  menuPortal: (provided) => ({ ...provided, zIndex: 2147483647, fontSize: "14px" }),
+  menu: (provided) => ({ ...provided, zIndex: 2147483647 }),
   valueContainer: (provided, _state) => ({
     ...provided,
     height: "24px",

--- a/src/pages/content/main.tsx
+++ b/src/pages/content/main.tsx
@@ -64,6 +64,7 @@ esSubsChanged.watch((language) => {
   const subsContainer = $streaming.getState().getSubsContainer();
   const subsNode = document.createElement("div");
   subsNode.id = "es";
+  subsNode.addEventListener("click", (e) => e.stopPropagation());
   subsContainer?.appendChild(subsNode);
   createRoot(subsNode).render(<Subs />);
 

--- a/src/pages/content/main.tsx
+++ b/src/pages/content/main.tsx
@@ -18,13 +18,21 @@ const handleTimeUpdate = () => {
   videoTimeUpdate();
 };
 
+let detectionRetries = 0;
+
 $streaming.watch((streaming) => {
   console.log("streaming changed", streaming);
-  document.body.classList.add("es-" + streaming.name);
 
-  if (streaming == null) {
+  if (streaming.name === "stub") {
+    if (detectionRetries < 5) {
+      detectionRetries++;
+      setTimeout(() => fetchCurrentStreamingFx(), 1500);
+    }
     return;
   }
+
+  detectionRetries = 0;
+  document.body.classList.add("es-" + streaming.name);
 
   esRenderSetings.watch(() => {
     console.log("Event:", "esRenderSetings");

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -19,7 +19,26 @@ const Popup = () => {
       permissions: ["scripting", "storage", "activeTab"],
       origins: [tab.url],
     });
-    if (isGranted) {
+    if (!isGranted) return;
+
+    // Inject into the current tab without reloading, so SPA players
+    // (e.g. Jellyfin) don't lose their playback state. Future page loads
+    // are handled automatically by webext-dynamic-content-scripts.
+    const [contentScript] = chrome.runtime.getManifest().content_scripts ?? [];
+    try {
+      if (contentScript?.css?.length) {
+        await chrome.scripting.insertCSS({
+          target: { tabId: tab.id },
+          files: contentScript.css,
+        });
+      }
+      await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        files: contentScript.js,
+      });
+      window.close();
+    } catch (e) {
+      // Fallback: reload if programmatic injection fails
       chrome.tabs.reload(tab.id);
     }
   };
@@ -39,7 +58,7 @@ const Popup = () => {
           </a>
         </li>
         <li onClick={handleRequestPermissions}>
-          <a className="es-popup-kinopub">Enable on Kinopub</a>
+          <a className="es-popup-kinopub">Enable on this site</a>
         </li>
         <li onClick={handleFaqLinkClick}>
           <a>FAQ</a>

--- a/src/streamings/jellyfin.ts
+++ b/src/streamings/jellyfin.ts
@@ -1,0 +1,213 @@
+import { esRenderSetings } from "@src/models/settings";
+import Service from "./service";
+import { parse } from "subtitle";
+import { esSubsChanged, rawSubsAdded } from "@src/models/subs";
+import { $video, getCurrentVideoFx } from "@src/models/videos";
+
+class Jellyfin implements Service {
+  name = "jellyfin";
+
+  private videoSubsObserver: MutationObserver | null = null;
+  private waitForElementGen = 0;
+  private initialized = false;
+
+  constructor() {
+    setInterval(() => {
+      const settingsButton = this.findOsdButton();
+      const easysubsSettings = document.querySelector(".es-settings");
+      if (settingsButton && !easysubsSettings) {
+        esRenderSetings();
+      }
+    }, 500);
+  }
+
+  private findOsdButton(): HTMLElement | null {
+    // Jellyfin renders two OSD button rows (one hidden), so we must pick the
+    // visible instance. The settings gear is `.btnVideoOsdSettings`; fall back
+    // to fullscreen. Note: `.btnSettings` is NOT the video OSD button — it
+    // belongs elsewhere in the Jellyfin UI, so we must not target it here.
+    const selectors = [".btnVideoOsdSettings", ".btnFullscreen"];
+    for (const selector of selectors) {
+      const candidates = document.querySelectorAll<HTMLElement>(selector);
+      for (const el of candidates) {
+        if (el.offsetParent !== null && el.getClientRects().length > 0) {
+          return el;
+        }
+      }
+    }
+    return null;
+  }
+
+  public init(): void {
+    if (this.initialized) return;
+    this.initialized = true;
+
+    getCurrentVideoFx();
+    $video.watch((video) => {
+      if (!video) return;
+
+      // Clean up observers from the previous video (SPA navigation)
+      this.videoSubsObserver?.disconnect();
+      this.videoSubsObserver = null;
+      this.waitForElementGen++;
+      const myGen = this.waitForElementGen;
+
+      // Suppress Jellyfin's native ::cue rendering via CSS injection.
+      // We cannot use track.mode="hidden" because Jellyfin immediately resets it
+      // via setTimeout(0) inside forceClearTextTrackActiveCues().
+      injectHideCueStyle();
+
+      // Track which TextTrack objects we already attached oncuechange to
+      const attachedTracks = new Set<TextTrack>();
+
+      const attachTrack = (track: TextTrack) => {
+        if (track.kind !== "subtitles" && track.kind !== "captions") return;
+        if (attachedTracks.has(track)) return;
+        attachedTracks.add(track);
+
+        track.oncuechange = () => {
+          // Only forward when this track is actually active
+          if (track.mode === "disabled") return;
+          const cues = [...(track.activeCues ?? [])] as VTTCue[];
+          if (cues.length === 0) return;
+          const text = cues
+            .map((c) => cleanVttText(c.text ?? ""))
+            .join("\n")
+            .trim();
+          if (!text) return;
+          rawSubsAdded([
+            {
+              start: cues[0].startTime * 1000,
+              end: cues[cues.length - 1].endTime * 1000,
+              text,
+            },
+          ]);
+        };
+      };
+
+      const getActiveLang = () => {
+        for (let i = 0; i < video.textTracks.length; i++) {
+          const t = video.textTracks[i];
+          if (t.mode !== "disabled" && (t.kind === "subtitles" || t.kind === "captions")) {
+            return t.language || t.label || "und";
+          }
+        }
+        return null;
+      };
+
+      // Attach to tracks that are already showing
+      for (let i = 0; i < video.textTracks.length; i++) {
+        if (video.textTracks[i].mode !== "disabled") {
+          attachTrack(video.textTracks[i]);
+        }
+      }
+
+      // Trigger subs pipeline if a track is already active
+      const lang = getActiveLang();
+      if (lang) esSubsChanged(lang);
+
+      // Handle subtitle language change (new track becomes showing)
+      video.textTracks.onchange = () => {
+        for (let i = 0; i < video.textTracks.length; i++) {
+          if (video.textTracks[i].mode !== "disabled") {
+            attachTrack(video.textTracks[i]);
+          }
+        }
+        const newLang = getActiveLang();
+        if (newLang) esSubsChanged(newLang);
+      };
+      video.textTracks.onaddtrack = (e) => {
+        if (e?.track) attachTrack(e.track);
+      };
+
+      // --- Fallback: custom .videoSubtitlesInner (Firefox / Edge / custom mode) ---
+      // Jellyfin creates this div only when useCustomSubtitles() is true.
+      waitForElement(".videoSubtitles", () => {
+        if (this.waitForElementGen !== myGen) return; // stale, a new video loaded
+        const subtitleSource = document.querySelector(".videoSubtitles");
+        if (!subtitleSource) return;
+        // Hide Jellyfin's custom div (EasySubs renders its own overlay)
+        (subtitleSource as HTMLElement).style.opacity = "0";
+        (subtitleSource as HTMLElement).style.pointerEvents = "none";
+
+        this.videoSubsObserver?.disconnect();
+        this.videoSubsObserver = new MutationObserver(() => {
+          const inner = subtitleSource.querySelector(".videoSubtitlesInner");
+          const text = inner ? getText(inner).trim() : "";
+          if (!text) return;
+          rawSubsAdded([
+            {
+              start: video.currentTime * 1000,
+              end: (video.currentTime + 5) * 1000,
+              text,
+            },
+          ]);
+        });
+        this.videoSubsObserver.observe(subtitleSource, { childList: true, subtree: true });
+      });
+    });
+  }
+
+  public async getSubs(_title: string) {
+    return parse("");
+  }
+
+  public getSubsContainer() {
+    const selector = document.querySelector(".videoPlayerContainer");
+    if (selector === null) throw new Error("Subtitles container not found");
+    return selector as HTMLElement;
+  }
+
+  public getSettingsButtonContainer() {
+    const selector = this.findOsdButton();
+    if (selector === null) throw new Error("Settings button container not found");
+    return selector;
+  }
+
+  public getSettingsContentContainer() {
+    return document.body;
+  }
+
+  public isOnFlight() {
+    return true;
+  }
+}
+
+// Injected once per page: hides the browser-native ::cue rendering so only
+// EasySubs' overlay is visible. We avoid track.mode="hidden" because Jellyfin
+// resets it synchronously via setTimeout(0).
+function injectHideCueStyle() {
+  if (document.getElementById("es-jellyfin-hide-cue")) return;
+  const style = document.createElement("style");
+  style.id = "es-jellyfin-hide-cue";
+  style.textContent =
+    "video.htmlvideoplayer::cue { opacity: 0 !important; color: transparent !important; text-shadow: none !important; }";
+  document.head.appendChild(style);
+}
+
+// Strip WebVTT tags before passing text to the EasySubs tokenizer:
+// <00:00:01.000> timestamp tags, <v Speaker>, <c.class>, <b>, </b>, etc.
+function cleanVttText(text: string): string {
+  return text
+    .replace(/<\d{2}:\d{2}:\d{2}\.\d{3}>/g, "")
+    .replace(/<\/?[^>]+>/g, "")
+    .trim();
+}
+
+function getText(node: ChildNode): string {
+  if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? "";
+  if (node.nodeName === "BR") return "\n";
+  return [...node.childNodes].map((el) => getText(el)).join("");
+}
+
+function waitForElement(selector: string, callBack: () => void) {
+  window.setTimeout(() => {
+    if (document.querySelector(selector)) {
+      callBack();
+    } else {
+      waitForElement(selector, callBack);
+    }
+  }, 300);
+}
+
+export default Jellyfin;

--- a/src/streamings/jellyfin.ts
+++ b/src/streamings/jellyfin.ts
@@ -3,6 +3,7 @@ import Service from "./service";
 import { parse } from "subtitle";
 import { esSubsChanged, rawSubsAdded } from "@src/models/subs";
 import { $video, getCurrentVideoFx } from "@src/models/videos";
+import type { Captions } from "@src/models/types";
 
 class Jellyfin implements Service {
   name = "jellyfin";
@@ -10,6 +11,7 @@ class Jellyfin implements Service {
   private videoSubsObserver: MutationObserver | null = null;
   private waitForElementGen = 0;
   private initialized = false;
+  private loadedCues: Captions = [];
 
   constructor() {
     setInterval(() => {
@@ -51,6 +53,7 @@ class Jellyfin implements Service {
       this.videoSubsObserver = null;
       this.waitForElementGen++;
       const myGen = this.waitForElementGen;
+      this.loadedCues = [];
 
       // Suppress Jellyfin's native ::cue rendering via CSS injection.
       // We cannot use track.mode="hidden" because Jellyfin immediately resets it
@@ -60,14 +63,36 @@ class Jellyfin implements Service {
       // Track which TextTrack objects we already attached oncuechange to
       const attachedTracks = new Set<TextTrack>();
 
+      const loadAllCues = (track: TextTrack): boolean => {
+        if (!track.cues || track.cues.length === 0) return false;
+        const subs = ([...track.cues] as VTTCue[])
+          .map((c) => ({ start: c.startTime * 1000, end: c.endTime * 1000, text: cleanVttText(c.text ?? "") }))
+          .filter((s) => s.text);
+        if (subs.length === 0) return false;
+        this.loadedCues = subs;
+        return true;
+      };
+
       const attachTrack = (track: TextTrack) => {
         if (track.kind !== "subtitles" && track.kind !== "captions") return;
         if (attachedTracks.has(track)) return;
         attachedTracks.add(track);
 
+        // Try to pre-load all cues now so getSubs() can return them and the
+        // progress bar has full subtitle data from the start.
+        loadAllCues(track);
+
         track.oncuechange = () => {
           // Only forward when this track is actually active
           if (track.mode === "disabled") return;
+
+          // If all cues were pre-loaded, videoTimeUpdate drives current subtitle display.
+          if (this.loadedCues.length > 0) return;
+
+          // Lazy-loading: cues may not have been ready at attach time — try again.
+          if (loadAllCues(track)) return;
+
+          // Final fallback: push the current active cue individually.
           const cues = [...(track.activeCues ?? [])] as VTTCue[];
           if (cues.length === 0) return;
           const text = cues
@@ -148,14 +173,17 @@ class Jellyfin implements Service {
     });
   }
 
-  public async getSubs(_title: string) {
+  public async getSubs(_title: string): Promise<Captions> {
+    // Return pre-loaded VTT cues when available so the full subtitle list
+    // lands in $rawSubs (used by the progress bar and time-based display).
+    if (this.loadedCues.length > 0) {
+      return this.loadedCues;
+    }
     return parse("");
   }
 
   public getSubsContainer() {
-    const selector = document.querySelector(".videoPlayerContainer");
-    if (selector === null) throw new Error("Subtitles container not found");
-    return selector as HTMLElement;
+    return document.body;
   }
 
   public getSettingsButtonContainer() {
@@ -169,7 +197,7 @@ class Jellyfin implements Service {
   }
 
   public isOnFlight() {
-    return true;
+    return false;
   }
 }
 

--- a/src/streamings/serviceStub.ts
+++ b/src/streamings/serviceStub.ts
@@ -6,7 +6,7 @@ class ServiceStub implements Service {
   name = "stub";
 
   public init(): void {
-    throw new Error("Not Implimented streaming service");
+    return;
   }
 
   public async getSubs() {

--- a/src/utils/getCurrentService.ts
+++ b/src/utils/getCurrentService.ts
@@ -10,6 +10,7 @@ import Udemy from "@src/streamings/udemy";
 import Kinopoisk from "@src/streamings/kinopoisk";
 import Amazon from "@src/streamings/amazon";
 import Inoriginal from "@src/streamings/inoriginal";
+import Jellyfin from "@src/streamings/jellyfin";
 
 export const getCurrentService = (): Service => {
   const titleContent = document.querySelector("title")?.textContent;
@@ -62,6 +63,16 @@ export const getCurrentService = (): Service => {
   // ) {
   //   return new Amazon();
   // }
+
+  const isJellyfin =
+    document.querySelector('meta[name="application-name"][content="Jellyfin"]') !== null ||
+    typeof (window as any).ApiClient !== "undefined" ||
+    (window.location.pathname.includes("/web/") &&
+      document.querySelector(".videoPlayerContainer") !== null);
+  if (isJellyfin) {
+    document.querySelector("html")?.setAttribute("id", "jellyfin");
+    return new Jellyfin();
+  }
 
   return new ServiceStub();
 };


### PR DESCRIPTION
## Summary

This PR adds support for **Jellyfin** as a streaming service, so EasySubs
can be used on self-hosted Jellyfin media servers.

## What's included

- **New Jellyfin service** (`src/streamings/jellyfin.ts`) implementing the
  `Service` interface: subtitle fetching, subs container, settings
  containers and live-stream detection.
- **Automatic detection** in `getCurrentService()` using the Jellyfin
  `application-name` meta tag, the global `ApiClient`, and a DOM fallback.
- **Subtitle track selector** (`JellyfinSubTrack` component) shown in the
  settings panel only when the active service is Jellyfin.
- **Reload-free injection**: the popup now injects the content script via
  `chrome.scripting` instead of reloading the tab, so SPA players (like
  Jellyfin) don't lose their playback state. Falls back to a reload if
  injection fails.
- **Service detection retries** when the page isn't ready yet, and a
  no-op `ServiceStub.init()` instead of throwing.
- **UI fixes**: stop click propagation inside the subtitles and settings
  containers so player controls aren't toggled, plus styling fixes for
  subtitles and the progress bar.
- Generalized the popup action label from "Enable on Kinopub" to
  "Enable on this site".

## Testing

Tested manually on a Jellyfin web player: service is detected, subtitles
render, the subtitle-track selector works, and translations behave as
expected.
