### PR TITLE
fix netflix subtitle interception

### DIFF
--- a/public/assets/js/netflix.js
+++ b/public/assets/js/netflix.js
@@ -5,7 +5,7 @@ const stringifyMock = JSON.stringify;
 // This is required to intercept subtitles from the server response.
 JSON.parse = function () {
   const data = parseMock.apply(this, arguments);
-  if (data && data.result && data.result.timedtexttracks) {
+  if (data && data.result && data.result.textTracks) {
     // Sends subtitles from the site page to the extension via a browser event
     window.dispatchEvent(new CustomEvent("esNetflixData", { detail: data.result }));
   }

--- a/src/streamings/netflix.ts
+++ b/src/streamings/netflix.ts
@@ -162,9 +162,9 @@ class Netflix implements Service {
       return;
     }
 
-    console.log("handleNetflixData", event.detail.timedtexttracks);
+    console.log("handleNetflixData", event.detail.textTracks);
 
-    const tracks: TTrack[] = event.detail.timedtexttracks;
+    const tracks: TTrack[] = event.detail.textTracks;
     console.log("tracks", tracks);
 
     tracks.forEach((track) => {
@@ -174,11 +174,11 @@ class Netflix implements Service {
 
       const title = this.getTrackTitle(track);
 
-      if (track.ttDownloadables[WEBVTT]?.urls) {
+      if (track.downloadables[WEBVTT]?.urls) {
         this.subCache.push({
           videoId: event.detail.movieId,
           title: title,
-          url: this.randomProperty(track.ttDownloadables[WEBVTT].urls).url,
+          url: this.randomProperty(track.downloadables[WEBVTT].urls).url,
         });
       }
     });


### PR DESCRIPTION
Some properties of the "intercepted" subtitle data object have been renamed.
- `result.timedtexttracks` -> `result.textTracks`
- `result.timedtexttracks.ttDownloadables` -> `result.textTracks.downloadables`

I could not test the fix since I did not manage to build it (I i.e. tried `npm install; npm run build` but it failed). And I could not import it without building because of a missing `manifest.json`.
Maybe it is just my local setup or I am doing sth. wrong; since I am not too familiar with chrome extensions or the JS ecosystem. I would be happy to test it ofc. if you could help me to resolve theses issues. But I did not have the time to dig into it more deeply.

But I use the same method inspired by an older version of your extension for my own personal subtitle extension (thanks!). So I used the same fix basically https://github.com/svehr/track_track/commit/ca8a8464ea40b6e12c5f93b2755f0df54d08d037
And the fix is just a straight forward renaming. So I think it should work for you too.
I hope it helps you in any case. 